### PR TITLE
Platform Agnostic Filepath

### DIFF
--- a/LowTierSisy.cs
+++ b/LowTierSisy.cs
@@ -33,7 +33,7 @@ namespace LowTierSisy
 
         public static string ModPath()
         {
-            return Assembly.GetExecutingAssembly().Location.Substring(0, Assembly.GetExecutingAssembly().Location.LastIndexOf(@"\"));
+            return Assembly.GetExecutingAssembly().Location.Substring(0, Assembly.GetExecutingAssembly().Location.LastIndexOf(Path.DirectorySeparatorChar));
         }
 
         public override void OnModUnload()


### PR DESCRIPTION
Uses `Path.DirectorySeparatorChar` instead of `@"\"` to allow the mod to work on non Win32 platforms, such as MacOS and Linux.